### PR TITLE
Buses should move.

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -57,6 +57,12 @@ L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
 
 <script>
 
+    const REFRESH_RATE = 20;
+    const EST_DATA_RATE = 10000;
+    // Momentum of the point. We want it to finish more or less 10% distance
+    // from the last known destination.
+    const MOMENTUM = Math.pow(0.10, REFRESH_RATE/EST_DATA_RATE);
+
     function fetchData(done) {
         const xhttp = new XMLHttpRequest();
         xhttp.onreadystatechange = function () {
@@ -102,7 +108,11 @@ L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
 
             if (oldMarkerMap.hasOwnProperty(hash) && oldMarkerMap[hash].length > 0) {
                 const marker = oldMarkerMap[hash].shift();
-                marker.setLatLng([row['Lat'], row['Lon']]);
+                const oldLL = marker.getLatLng();
+                marker.setLatLng([
+                  MOMENTUM*oldLL.lat + (1.-MOMENTUM)*row['Lat'],
+                  MOMENTUM*oldLL.lng + (1.-MOMENTUM)*row['Lon']
+                ]);
                 marker.setPopupContent(JSON.stringify(row, undefined, 1));
                 if (newMarkerMap.hasOwnProperty(hash)) {
                     newMarkerMap[hash].push(marker);
@@ -169,7 +179,6 @@ L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
     function update() {
         fetchData(function (data) {
             currentData = data;
-            refreshView();
         });
     }
 
@@ -194,6 +203,7 @@ L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
 
     update();
     setInterval(update, 2000);
+    setInterval(refreshView, REFRESH_RATE);
 
     document.getElementById("lines").value = localSettings.lines.join(",");
 

--- a/update.py
+++ b/update.py
@@ -35,4 +35,6 @@ def main():
 
         time.sleep(10)
 
-main()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Added pseudo-momentum to buses, for smooth ride through the streets.

Each frame buses move by an epsilon percent of distance towards their last known location. Epsilon is chosen such that buses cover 90% of remaining distance in 10 seconds (50% of distance in 3 seconds). It looks really nice in comparison to still-and-sometimes-teleporting buses and indicates the bus direction well. It has some drawbacks:
- Major: It increases lag, but it's bounded by ~11 seconds anyway, just more consistently.
- Major (but just a bug): During a period of inactivity (e.g. user looking at different browser tab) current location doesn't change at all, causing buses to quickly fly over buildings and everything. It may actually be a feature.
- Minor: Buses cut corners from time to time.

Anyway, coolness and clearness of this pull request is worth those drawbacks. Pls merge.